### PR TITLE
Add warning to README to set attribute size

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Appwrite collection permissions see their [documentation](https://appwrite.io/do
 
 **D. Add following attributes in the tables**
 
-> **Note: Appwrite cloud uses apprite v1.1.2 as of AUG 2023 and doesn't support relations**
+> Note: Set each attribute to be size 1024 bytes in order to accomodate the strings submitted in each field, otherwise user submissions will fail when the API call is made.
 
 6. User Collection Attributes
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Appwrite collection permissions see their [documentation](https://appwrite.io/do
 
 **D. Add following attributes in the tables**
 
-> Note: Set each attribute to be size 1024 bytes in order to accomodate the strings submitted in each field, otherwise user submissions will fail when the API call is made.
+> **Note: Appwrite cloud uses apprite v1.1.2 as of AUG 2023 and doesn't support relations**
+> **Note: Set each attribute to be size 1024 bytes in order to accomodate the strings submitted in each field, otherwise user submissions will fail when the API call is made.**
 
 6. User Collection Attributes
 


### PR DESCRIPTION
1024 is an arbitrary size - I picked it because initially 128 was not big enough and it was causing errors for me. 

I've also removed the warning about relations because appwrite now supports them.

Is this is the size that you use in your production app? Do you have different sizes for each attribute? That would be really helpful information to share / update the README with. 